### PR TITLE
Migrate to native namespaces

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[egg_info]
-tag_build = 
-tag_date = 0
-tag_svn_revision = 0
-

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
+from setuptools import setup, find_namespace_packages
 from xstatic.pkg import termjs as xs
 
 # The README.txt file should be written in reST so that PyPI can use
-# it to generate your project's PyPI page. 
+# it to generate your project's PyPI page.
 long_description = open('README.rst').read()
-
-from setuptools import setup, find_packages
 
 setup(
     name=xs.PACKAGE_NAME,
@@ -18,10 +17,8 @@ setup(
     license=xs.LICENSE,
     url=xs.HOMEPAGE,
     platforms=xs.PLATFORMS,
-    packages=find_packages(),
-    namespace_packages=['xstatic', 'xstatic.pkg', ],
+    packages=find_namespace_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=[],  # nothing! :)
-                          # if you like, you MAY use the 'XStatic' package.
+    install_requires=[],
 )

--- a/xstatic/__init__.py
+++ b/xstatic/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/xstatic/pkg/__init__.py
+++ b/xstatic/pkg/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/xstatic/pkg/termjs/__init__.py
+++ b/xstatic/pkg/termjs/__init__.py
@@ -13,7 +13,7 @@ NAME = __name__.split('.')[-1] # package name (e.g. 'foo' or 'foo_bar')
 
 VERSION = '0.0.7' # version of the packaged files, please use the upstream
                   # version number
-BUILD = '0' # our package build number, so we can release new builds
+BUILD = '1' # our package build number, so we can release new builds
              # with fixes for xstatic stuff.
 PACKAGE_VERSION = VERSION + '.' + BUILD # version used for PyPi
 


### PR DESCRIPTION
Rather embarrassingly, https://github.com/openstack/horizon still depends on this package :see_no_evil: `pkg_resources` has been removed from setuptools 82.0.0. While we are hoping to get it restored in some way (see [here](https://github.com/pypa/setuptools/issues/5174) and [here](https://github.com/pypa/setuptools/issues/863)), `pkg_resources`-style namespaces have long been deprecated in favour of [native namespaces](https://peps.python.org/pep-0420/).

Migrate this package to native namespaces and bump the package version. This mirrors what has been done for the many other xstatic packages [maintained by the OpenStack community](https://review.opendev.org/q/topic:%22remove-pkg_resources%22+project:%22%5Eopenstack/xstatic-.*%22+is:merged)

@takluyver I am genuinely sorry/embarrassed to have to be proposing this PR :sweat_smile: This thing is ancient and no one should be depending on it. Sadly, there is some urgency in merging and releasing this since much of OpenStack's CI is currently broken due to Horizon's dependency on these xstatic packages. This isn't your problem of course, so if you're not able/do not want to review this I'd ask that you either (a) add the `openstackci` user to the project on PyPI so we can migrate it back to opendev.org (you could mark this as archived at the same time) **or** (b) add me (`stephenfin`) as a maintainer here and on PyPI so I can do the necessary work. A quick review of my GitHub and Gerrit history should demonstrate that I am fully "vouched for". You can also verify me using my work email (my GH username at redhat.com). Cheers, and apologies again.
